### PR TITLE
Fix V3118

### DIFF
--- a/Core/NetChannel.cs
+++ b/Core/NetChannel.cs
@@ -85,7 +85,7 @@ namespace MOUSE.Core
                         continuation.Expiration.Cancel();
                         if (!continuation.TCS.Task.IsCompleted)
                         {
-                            var durationMs = (DateTime.Now - continuation.StartTime).Milliseconds;
+                            var durationMs = (DateTime.Now - continuation.StartTime).TotalMilliseconds;
                             _requestDurationTimer.Record(durationMs, TimeUnit.Milliseconds);
                             Logger.NetChannelRequestCompleted(Node, this, msg, operationHeader.RequestId, durationMs);
 


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- 'Milliseconds' component of TimeSpan is used, which does not represent full time interval. Possibly 'TotalMilliseconds' value was intended instead. Core NetChannel.cs 88