### PR TITLE
Fix V3118

### DIFF
--- a/Core/Node.cs
+++ b/Core/Node.cs
@@ -162,7 +162,7 @@ namespace MOUSE.Core
             PendingConnection continuation;
             if (_pendingConnections.TryRemove(transportChannel.EndPoint, out continuation))
             {
-                _logger.ConnectionSucceeded(this, continuation.Target, channel, (DateTime.Now - continuation.StartTime).Milliseconds);
+                _logger.ConnectionSucceeded(this, continuation.Target, channel, (DateTime.Now - continuation.StartTime).TotalMilliseconds);
                 continuation.Expiration.Cancel();
                 continuation.TCS.SetResult(channel);
             }


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

- Milliseconds component of TimeSpan is used, which does not represent full time interval. Possibly 'TotalMilliseconds' value was intended instead. Core Node.cs 165