### PR TITLE
Fix V3008

### DIFF
--- a/Core.Azure.ServiceFabric/ServiceFabricActorSystemNetNode.cs
+++ b/Core.Azure.ServiceFabric/ServiceFabricActorSystemNetNode.cs
@@ -50,7 +50,6 @@ namespace MOUSE.Core.Azure.ServiceFabric
             INetNodeConfig config = null, IBufferPool bufferPool = null, IPEndPoint publicAddress = null, Func<TActor> actorFactory = null)
             : base(name, net, coreLogger, messageSerializer, null, config, publicAddress)
         {
-            _logger = logger;
             ChannelFactory = (node, transport) =>
             {
                 var channel = new ActorSystemNetChannel(node, transport, messageSerializer, coreLogger, config, bufferPool);


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- The '_logger' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 67, 53. Core.Azure.ServiceFabric ServiceFabricActorSystemNetNode.cs 67

I think it not necessary to assign it twice 